### PR TITLE
fix: require jobId in task response

### DIFF
--- a/src/models/dataTypes.ts
+++ b/src/models/dataTypes.ts
@@ -9,7 +9,7 @@ export enum OperationStatus {
 
 export interface ITaskResponse<T> {
   id: string;
-  jobId?: string;
+  jobId: string;
   description: string;
   parameters: T;
   created: string;

--- a/src/taskHandler.ts
+++ b/src/taskHandler.ts
@@ -27,7 +27,7 @@ export class TaskHandler {
     this.heartbeatClient = new HeartbeatClient(logger, heartbeatIntervalMs, heartbeatUrl, httpRetryConfig);
   }
 
-  public async waitForTask<T>(): Promise<ITaskResponse<T> | null> {
+  public async waitForTask<T>(): Promise<ITaskResponse<T>> {
     let task: ITaskResponse<T> | null;
     do {
       this.logger.debug(`[TaskHandler][waitForTask]`);


### PR DESCRIPTION
In the ITaskResponse interface, change jobId from optional to required.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: #20 
Closes #20 