### PR TITLE
fix: throws error instead of returning undefined (MAPCO-2988)

### DIFF
--- a/src/jobManagerClient.ts
+++ b/src/jobManagerClient.ts
@@ -76,7 +76,7 @@ export class JobManagerClient extends HttpClient {
     }
   }
 
-  public async getJob<T, P>(jobId: string, shouldReturnTasks = false): Promise<IJobResponse<T, P> | undefined> {
+  public async getJob<T, P>(jobId: string, shouldReturnTasks = false): Promise<IJobResponse<T, P>> {
     const getJobUrl = this.getJobUrl(jobId);
     try {
       this.logger.debug({

--- a/src/jobManagerClient.ts
+++ b/src/jobManagerClient.ts
@@ -96,7 +96,7 @@ export class JobManagerClient extends HttpClient {
         msg: `failed to getJob for jobId=${jobId}`,
         errorMessage: (err as { message: string }).message,
       });
-      return undefined;
+      throw err;
     }
   }
 


### PR DESCRIPTION
Fix get job from returning undefined in case of a failure.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |