### PR TITLE
fix: add reason to rejected tasks that are not recoverable

### DIFF
--- a/src/taskHandler.ts
+++ b/src/taskHandler.ts
@@ -95,6 +95,7 @@ export class TaskHandler {
       } else {
         payload = {
           status: OperationStatus.FAILED,
+          reason,
         };
       }
       this.logger.info({


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

There's no reason not to include it. When a task fails, you'd wish to have a reason in the database. This PR adds that.